### PR TITLE
chore: add lint/build workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - name: Install dependencies
+        run: flutter pub get
+      - name: Format and fix
+        run: |
+          dart format lib test
+          dart fix --apply
+      - name: Analyze
+        run: flutter analyze
+
+  build-android:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - name: Install dependencies
+        run: flutter pub get
+      - name: Build APK
+        run: flutter build apk --debug
+
+  build-windows:
+    runs-on: windows-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - name: Enable Windows desktop
+        run: flutter config --enable-windows-desktop
+      - name: Install dependencies
+        run: flutter pub get
+      - name: Build Windows
+        run: flutter build windows --debug
+
+  trigger-ios:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - name: Trigger Codemagic iOS build
+        env:
+          CODEMAGIC_APP_ID: ${{ secrets.CODEMAGIC_APP_ID }}
+          CODEMAGIC_WORKFLOW_ID: ios-workflow
+          CODEMAGIC_TOKEN: ${{ secrets.CODEMAGIC_TOKEN }}
+        run: |
+          curl -H "x-auth-token: $CODEMAGIC_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d '{"appId": "'$CODEMAGIC_APP_ID'", "workflowId": "'$CODEMAGIC_WORKFLOW_ID'", "branch": "'${GITHUB_REF##*/}'"}' \
+            https://api.codemagic.io/builds

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1,0 +1,11 @@
+workflows:
+  ios-workflow:
+    name: iOS Build
+    environment:
+      flutter: stable
+      xcode: latest
+    scripts:
+      - flutter pub get
+      - flutter build ipa --release --no-codesign
+    artifacts:
+      - build/ios/ipa/*.ipa


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for linting and building on Android/Windows
- trigger Codemagic to build iOS
- add Codemagic configuration for iOS builds

## Testing
- `flutter analyze` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository no longer signed)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fd536d68083309e3d079e0889ccbe